### PR TITLE
docs: add readmes for private stable coin templates

### DIFF
--- a/templates/private_stable_coin/issuer-no-user-badge/README.md
+++ b/templates/private_stable_coin/issuer-no-user-badge/README.md
@@ -1,0 +1,90 @@
+# Private Stable Coin — Issuer (no user badge)
+
+A privacy-preserving stable coin template for the [Tari](https://www.tari.com/) network in which **anyone can hold
+and transfer the coin** — no registration with the issuer is required to receive it. Token amounts are confidential
+(stealth resource) and the issuer relies on *reactive* controls (view key, recall, UTXO freeze/burn) rather than
+gating who may hold the coin.
+
+See [`../issuer`](../issuer/README.md) for the variant that restricts holding to badge-registered accounts, and the
+[privacy tradeoff](#privacy-tradeoff-no-badge-vs-user-badge) section below for how the two differ.
+
+## How it works
+
+`instantiate` creates four resources and one component:
+
+| Resource | Type | Purpose |
+|---|---|---|
+| Admin badge | Non-fungible | Gates all privileged operations; returned to the caller of `instantiate`. |
+| User badge | Non-fungible | An **optional registry entry**, not an access requirement. Minted by admins via `create_new_user` for known/KYC'd users; stores `UserData` (user id, account, created epoch) and `UserMutableData` (blacklist flag, wrapped-exchange limit). Used to look up a user's account for recalls and to track exchange limits. |
+| Stable coin | Stealth (confidential) | The coin itself. Amounts are hidden on-ledger; the issuer holds a **view key** that can reveal them. Mint/burn/recall require an admin badge — **deposit and withdraw are unrestricted**. |
+| Wrapped token (optional) | Public fungible | A transparent twin of the coin (`w<SYMBOL>`), exchangeable 1:1 (minus a configurable fee) for use where confidential resources aren't supported. |
+
+Because the coin resource has no deposit/withdraw rules and no authorization hook, transfers are ordinary
+peer-to-peer stealth transfers between any accounts (see the
+`it_allows_anyone_to_receive_tokens_without_badge` test).
+
+All component methods default to requiring an admin badge, including the wrapped-token exchange methods — exchanges
+are facilitated by the issuer rather than called directly by end users.
+
+### Method summary
+
+All methods require an admin badge:
+
+- `increase_supply` / `decrease_supply` — mint into / burn from the issuer vault
+- `withdraw` / `deposit` — move coins out of / into the issuer vault
+- `create_new_user` / `create_new_admin` — mint badges
+- `blacklist_user` / `remove_from_blacklist` — recall a registered user's badge into a quarantine vault (and back)
+- `recall_revealed_tokens` — pull a revealed amount out of a registered user's account vault
+- `freeze_utxos` / `unfreeze_utxos`, `burn_utxo` — UTXO-level controls
+- `exchange_stable_for_wrapped_tokens` / `exchange_wrapped_for_stable_tokens` — convert between the stealth coin and
+  the public wrapped token (requires the user's badge proof in addition to admin access)
+- `pause` — records a paused flag and emits an event. Note: without the deposit authorization hook of the
+  [`issuer`](../issuer/README.md) variant there is no resource-level enforcement point, so pausing does not block
+  transfers on-chain.
+- `set_user_exchange_limit`, `set_config_transfer_fee_fixed`, `set_config_transfer_fee_percentage`
+
+## Privacy tradeoff: no badge vs. user badge
+
+This variant trades issuer control for holder privacy. Compared to the
+[user-badge variant](../issuer/README.md):
+
+What holders gain:
+
+- **No public membership list.** In the badge variant, every holder carries a publicly visible badge NFT in their
+  account, so the complete customer set can be enumerated by anyone scanning the ledger. Here, an account holding
+  the coin carries no public marker beyond having a vault for the resource, and receiving the coin requires no
+  issuer involvement at all.
+- **No public identity registry.** Badges (where issued) still record `user_id` → account on-ledger, but only for
+  users the issuer chooses to register — not as a precondition for holding the coin.
+- **Unrestricted peer-to-peer transfers.** Deposits aren't intercepted by an authorization hook that inspects the
+  receiving account, so third parties can't rely on a resource-level checkpoint to map the payment graph.
+
+What the issuer gives up:
+
+- **No proactive gating.** Anyone, including a sanctioned or unknown party, can receive the coin. In the badge
+  variant a transfer to an unregistered account fails atomically; here it succeeds.
+- **Blacklisting is bookkeeping, not enforcement.** Recalling a user's badge updates the registry but does not stop
+  the account from continuing to send and receive the coin. Enforcement must instead use the reactive tools:
+  reveal amounts via the **view key**, `recall_revealed_tokens`, `freeze_utxos`, or `burn_utxo`.
+- **Pause is advisory** (see method summary above).
+
+Note that in **both** variants the issuer holds the resource view key and can reveal amounts; confidentiality is
+from the public, not from the issuer.
+
+Choose this variant when open transferability and holder privacy matter most and reactive compliance controls are
+acceptable; choose [`issuer`](../issuer/README.md) when regulation demands that only vetted accounts ever hold the
+token.
+
+## Building and testing
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+cargo test
+```
+
+## Manifests
+
+- [`manifests/initialize.rs`](manifests/initialize.rs) — instantiates the component (initial supply, symbol,
+  metadata, divisibility, view key, wrapped-token flag) and deposits the admin badge.
+- [`manifests/create_user_and_transfer.rs`](manifests/create_user_and_transfer.rs) — registers a new user (minting
+  their badge) and transfers them funds in one transaction.

--- a/templates/private_stable_coin/issuer-no-user-badge/manifests/initialize.rs
+++ b/templates/private_stable_coin/issuer-no-user-badge/manifests/initialize.rs
@@ -1,4 +1,4 @@
-use template_xxx as StableCoin;
+use StableCoin;
 
 pub fn main() {
     let addr = new_component_addr!();

--- a/templates/private_stable_coin/issuer/README.md
+++ b/templates/private_stable_coin/issuer/README.md
@@ -1,0 +1,86 @@
+# Private Stable Coin — Issuer (with user badge)
+
+A privacy-preserving stable coin template for the [Tari](https://www.tari.com/) network in which **every holder must
+be registered with the issuer**. Token amounts are confidential (stealth resource), but only accounts holding a
+non-fungible *user badge* issued by an admin may receive or hold the coin.
+
+See [`../issuer-no-user-badge`](../issuer-no-user-badge/README.md) for the variant without holder registration, and
+the [privacy tradeoff](#privacy-tradeoff-of-the-user-badge) section below for how the two differ.
+
+## How it works
+
+`instantiate` creates four resources and one component:
+
+| Resource | Type | Purpose |
+|---|---|---|
+| Admin badge | Non-fungible | Gates all privileged operations; returned to the caller of `instantiate`. |
+| User badge | Non-fungible | Per-user authentication token. Minted by admins via `create_new_user`, recallable by admins. Stores `UserData` (user id, account, created epoch) and `UserMutableData` (blacklist flag, wrapped-exchange limit). |
+| Stable coin | Stealth (confidential) | The coin itself. Amounts are hidden on-ledger; the issuer holds a **view key** that can reveal them. Mint/burn/recall require an admin badge. |
+| Wrapped token (optional) | Public fungible | A transparent twin of the coin (`w<SYMBOL>`), exchangeable 1:1 (minus a configurable fee) for use where confidential resources aren't supported. |
+
+The stable coin resource is built with `depositable`/`withdrawable` rules requiring a user or admin badge, **plus an
+authorization hook** (`authorize_user_deposit`) that runs on every deposit. The hook inspects the receiving account
+and panics unless that account holds a user badge in a vault — so tokens can only ever land in registered accounts.
+The hook also rejects all deposits while the coin is paused.
+
+### Method summary
+
+Admin (requires admin badge):
+
+- `increase_supply` / `decrease_supply` — mint into / burn from the issuer vault
+- `withdraw` / `deposit` — move coins out of / into the issuer vault
+- `create_new_user` / `create_new_admin` — mint badges
+- `blacklist_user` / `remove_from_blacklist` — recall a user's badge into a quarantine vault (and back)
+- `recall_revealed_tokens` — pull a revealed amount out of a user's account vault
+- `freeze_utxos` / `unfreeze_utxos`, `burn_utxo` — UTXO-level controls
+- `pause` — block all deposits of the coin
+- `set_user_exchange_limit`, `set_config_transfer_fee_fixed`, `set_config_transfer_fee_percentage`
+
+User (requires user badge proof):
+
+- `exchange_stable_for_wrapped_tokens` — burn stable coins, mint wrapped tokens (fee applies, limited per user)
+- `exchange_wrapped_for_stable_tokens` — burn wrapped tokens, mint stable coins
+
+## Privacy tradeoff of the user badge
+
+The user badge buys the issuer **proactive compliance** at the cost of **holder privacy**. The stealth resource hides
+*amounts*, but the badge mechanism makes *participation* public:
+
+- **Holders are publicly enumerable.** The user badge is an ordinary non-fungible sitting in each user's account
+  vault. Anyone scanning the ledger can list every account that holds a badge for this coin — i.e. the complete set
+  of customers — even though no balance is visible.
+- **Badge data is a public registry.** Each badge's on-ledger data links a `user_id` to a specific account address,
+  along with its creation epoch, blacklist status, and exchange limit. If the issuer's user ids correlate with KYC
+  records, this is a persistent public mapping from identity to account.
+- **Deposits reveal the recipient.** The auth hook must inspect the receiving account's vaults at deposit time, so a
+  transfer's destination account is visible on-ledger. The transaction graph (who pays whom, and when) is
+  observable; only the amounts stay confidential.
+- **Events name users.** Exchanges and admin actions emit events carrying `user_id`, adding a public activity trail
+  per user.
+
+What the issuer gains in exchange:
+
+- **Only vetted accounts can ever hold the coin** — enforced at the resource level, not by policy. A transfer to an
+  unregistered account fails atomically.
+- **Blacklisting is immediate and total**: recalling a user's badge means the auth hook rejects any further deposits
+  to them.
+- **Pause is enforced on-chain**: the hook blocks every deposit while paused.
+
+If holders' privacy matters more than proactive gating — and reactive controls (view key, recall, UTXO
+freeze/burn) are sufficient for compliance — use
+[`issuer-no-user-badge`](../issuer-no-user-badge/README.md) instead.
+
+Note that in **both** variants the issuer holds the resource view key and can reveal amounts; confidentiality is
+from the public, not from the issuer.
+
+## Building and testing
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+cargo test
+```
+
+## Manifests
+
+- [`manifests/create_user_and_transfer.rs`](manifests/create_user_and_transfer.rs) — registers a new user (minting
+  their badge) and transfers them funds in one transaction.


### PR DESCRIPTION
## Summary

- Add a README for each of the two private stable coin templates (`issuer` and `issuer-no-user-badge`) covering the resources created at instantiation, method summaries by required authorization, build/test instructions, and manifests.
- Each README details the privacy tradeoff of the user badge: the `issuer` variant gains proactive compliance (deposit auth hook, enforced blacklisting/pause) at the cost of a publicly enumerable holder set and an on-ledger `user_id` → account registry; the no-badge variant keeps holders unlisted with open peer-to-peer stealth transfers, relying on reactive controls (view key, recall, UTXO freeze/burn).
- Fix the `initialize.rs` manifest import in `issuer-no-user-badge` (`use template_xxx as StableCoin` → `use StableCoin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)